### PR TITLE
Fixed an invalid call to a template

### DIFF
--- a/Admin/TranslationAdmin.php
+++ b/Admin/TranslationAdmin.php
@@ -26,7 +26,7 @@ class TranslationAdmin extends Admin {
 
         $likes = $this->modelManager->getEntityManager($subject)->getRepository(get_class($subject))->findOneLikes($subject);
 
-        $help = $this->getConfigurationPool()->getContainer()->get('templating')->render('PierstovalTranslationBundle:Translate:sonata_translations_like_help.html.twig', array('translations' => $likes));
+        $help = $this->getConfigurationPool()->getContainer()->get('templating')->render('PierstovalTranslationBundle:Translation:sonata_translations_like_help.html.twig', array('translations' => $likes));
 
         $formMapper
             ->add('locale', 'text', array('disabled'=>true))


### PR DESCRIPTION
The call to sonata_translations_like_help.html.twig was called with the
wrong prefix (Translate instead of Translation where the file is
located)

This is corrected in this Pull request